### PR TITLE
[ci skip] adding user @inducer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @jan-janssen
+* @inducer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,4 +53,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - inducer
     - jan-janssen


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @inducer as instructed in #3.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.
